### PR TITLE
Add metrics tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,22 @@
+name: Python package
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest
+      - name: Run tests
+        run: |
+          pytest -q
+          python -m py_compile assistant.py metrics.py tests/test_metrics.py

--- a/metrics.py
+++ b/metrics.py
@@ -1,0 +1,76 @@
+import csv
+import os
+import time
+from collections import deque
+from contextlib import contextmanager
+
+class MetricsLogger:
+    def __init__(self, path="metrics.csv", enabled=True, rolling=5):
+        self.path = path
+        self.enabled = enabled
+        self.rolling = rolling
+        self.recent = deque(maxlen=rolling)
+        if self.enabled and not os.path.exists(self.path):
+            with open(self.path, "w", newline="") as f:
+                writer = csv.writer(f)
+                writer.writerow([
+                    "timestamp",
+                    "record_audio",
+                    "transcribe",
+                    "generate_response",
+                    "speak",
+                    "total",
+                ])
+        self.current = {}
+
+    @contextmanager
+    def time(self, key: str):
+        start = time.perf_counter()
+        yield
+        duration = time.perf_counter() - start
+        self.current[key] = duration
+
+    def log_run(self):
+        total = sum(v for v in self.current.values())
+        self.current["total"] = total
+        if self.enabled:
+            with open(self.path, "a", newline="") as f:
+                writer = csv.writer(f)
+                writer.writerow(
+                    [
+                        time.strftime("%Y-%m-%d %H:%M:%S"),
+                        self.current.get("record_audio", 0),
+                        self.current.get("transcribe", 0),
+                        self.current.get("generate_response", 0),
+                        self.current.get("speak", 0),
+                        total,
+                    ]
+                )
+        self.recent.append(dict(self.current))
+        self.print_summary()
+        self.current = {}
+
+    def rolling_average(self):
+        if not self.recent:
+            return {}
+        keys = ["record_audio", "transcribe", "generate_response", "speak", "total"]
+        avg = {k: 0 for k in keys}
+        for entry in self.recent:
+            for k in keys:
+                avg[k] += entry.get(k, 0)
+        for k in keys:
+            avg[k] /= len(self.recent)
+        return avg
+
+    def print_summary(self):
+        print("--- Timing Summary ---")
+        for k, v in self.current.items():
+            if k == "total":
+                continue
+            print(f"{k}: {v:.2f}s")
+        print(f"total: {self.current.get('total', 0):.2f}s")
+        if len(self.recent) > 1:
+            avg = self.rolling_average()
+            print("Rolling average (last {} runs):".format(len(self.recent)))
+            for k, v in avg.items():
+                print(f"{k}: {v:.2f}s")

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,59 @@
+import csv
+import builtins
+import time
+from metrics import MetricsLogger
+
+
+def test_time_records_duration(monkeypatch):
+    logger = MetricsLogger(enabled=False)
+    counter = iter([1.0, 2.0])
+    monkeypatch.setattr(time, "perf_counter", lambda: next(counter))
+    with logger.time("record_audio"):
+        pass
+    assert logger.current["record_audio"] == 1.0
+
+
+def test_log_run_writes_csv(tmp_path, monkeypatch):
+    path = tmp_path / "metrics.csv"
+    logger = MetricsLogger(path=path, enabled=True)
+    logger.current = {
+        "record_audio": 1.0,
+        "transcribe": 2.0,
+        "generate_response": 3.0,
+        "speak": 4.0,
+    }
+    monkeypatch.setattr(time, "strftime", lambda *_: "2025-01-01 00:00:00")
+    logger.log_run()
+    with open(path) as f:
+        rows = list(csv.reader(f))
+    assert rows[0] == [
+        "timestamp",
+        "record_audio",
+        "transcribe",
+        "generate_response",
+        "speak",
+        "total",
+    ]
+    assert len(rows) == 2
+    assert float(rows[1][1]) == 1.0
+    assert float(rows[1][2]) == 2.0
+    assert float(rows[1][3]) == 3.0
+    assert float(rows[1][4]) == 4.0
+    assert float(rows[1][5]) == 10.0
+
+
+def test_rolling_average(monkeypatch):
+    logger = MetricsLogger(enabled=False, rolling=5)
+    monkeypatch.setattr(time, "strftime", lambda *_: "2025-01-01 00:00:00")
+    for i in range(3):
+        logger.current = {
+            "record_audio": i + 1,
+            "transcribe": i + 1,
+            "generate_response": i + 1,
+            "speak": i + 1,
+        }
+        logger.log_run()
+    avg = logger.rolling_average()
+    assert avg["record_audio"] == 2.0
+    assert avg["total"] == 8.0
+


### PR DESCRIPTION
## Summary
- add pytest-based tests for the metrics logger
- ensure the context manager measures durations
- confirm CSV logging and rolling averages work

## Testing
- `pytest -q`
- `python -m py_compile assistant.py metrics.py tests/test_metrics.py`


------
https://chatgpt.com/codex/tasks/task_e_688195abf35c832a8b6b07722e1d8ecb