### PR TITLE
Fix f-string newline escape for Python 3.10

### DIFF
--- a/rag_prompt_builder.py
+++ b/rag_prompt_builder.py
@@ -14,6 +14,7 @@ def build_prompt(query: str, chunks: List[str]) -> str:
 
     print("--- Added Chunks ---")
     for idx, chunk in enumerate(chunks, 1):
-        print(f"{idx}: {chunk[:60].replace('\n', ' ')}")
+        snippet = chunk[:60].replace("\n", " ")
+        print(f"{idx}: {snippet}")
 
     return final_prompt


### PR DESCRIPTION
## Summary
- fix f-string usage in `rag_prompt_builder` that caused SyntaxError during test import

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6881aceead24832ab9cad2cd26f4d940